### PR TITLE
Add restore button to courses page

### DIFF
--- a/classes/lifecycle/course_table.php
+++ b/classes/lifecycle/course_table.php
@@ -41,7 +41,8 @@ class course_table extends \table_sql
 
         // Action buttons string
         $this->strings = [
-            'download' => get_string('download')
+            'download' => get_string('download'),
+            'restore' => get_string('restore'),
         ];
 
         // Build the SQL.
@@ -119,6 +120,13 @@ class course_table extends \table_sql
                 new \moodle_url('', ['action' => 'download', 'id' => $row->id, 'sesskey' => sesskey()]),
                 new \pix_icon('t/download', $this->strings['download']),
                 $this->strings['download']
+            )
+        );
+        $actionmenu->add_primary_action(
+            new \action_menu_link_primary(
+                new \moodle_url('', ['action' => 'restore', 'id' => $row->id, 'sesskey' => sesskey()]),
+                new \pix_icon('t/restore', $this->strings['restore']),
+                $this->strings['restore']
             )
         );
 

--- a/courses.php
+++ b/courses.php
@@ -58,11 +58,24 @@ if ($action) {
     }
 
     // Perform the action.
-    if ($action == 'download') {
-        // Download the file.
-        send_stored_file($file, 0, 0, true);
-    } else {
-        throw new coding_exception("action must be 'download'");
+    switch ($action) {
+        case 'download':
+            // Download the file.
+            send_stored_file($file, 0, 0, true);
+            break;
+        case 'restore':
+            $context = \context_system::instance();
+            $restoreurl = new \moodle_url('/backup/restore.php',
+                array(
+                    'contextid' => $context->id,
+                    'pathnamehash' => $file->get_pathnamehash(),
+                    'contenthash' => $file->get_contenthash(),
+                )
+            );
+            redirect($restoreurl);
+        default:
+            throw new coding_exception("action '{$action}' is not supported.");
+            break;
     }
 }
 


### PR DESCRIPTION
Adds a action button to restore on admin/tool/lcbackupcoursestep/courses.php

![Screenshot 2024-09-26 at 09-18-31 UNKN Backed up courses cqu-he](https://github.com/user-attachments/assets/a921bd5e-a3e8-4cea-b9e7-991473e59efc)

**Testing instructions**

1. Create a test site with a couple courses (use admin/tool/generator/cli/maketestsite.php).
2. Create a category where you can move the courses into, I created a category with name "Archive me".
3. Move a couple courses in the the newly created category.
4. Open admin/tool/lifecycle/workflowdrafts.php and click "Create new workflow" button.
5. Give the workflow a new title, then click "Save changes".
6. From the "Add new trigger instance" dropdown, select "Categories Trigger"
7. Give the new trigger a name, I gave: this "When course in category", and Select the Category "Archive me" from the dropdown then click Save changes.
8. From the "Add new step instance" dropdown, select "Backup course step"
9. Give the new step a name, I gave this: "Backup course", then click "Save changes".
10. Open admin/tool/lifecycle/workflowdrafts.php and click the Activate button for the newly created workflow.
11. In a terminal execute the following command
```
php admin/cli/scheduled_task.php --execute="\tool_lifecycle\task\lifecycle_task"
```
12. Open admin/tool/lcbackupcoursestep/courses.php
13. Click the restore button and confirm you land on the course restore page.


