### PR TITLE
Add file size to backup up courses table

### DIFF
--- a/classes/lifecycle/course_table.php
+++ b/classes/lifecycle/course_table.php
@@ -48,7 +48,7 @@ class course_table extends \table_sql
         // Build the SQL.
         $fields = 'f.id as id,
                    co.id as courseid, co.shortname as courseshortname, co.fullname as coursefullname,
-                   f.filename as filename, f.timecreated as createdat';
+                   f.filename as filename, f.filesize as filesize, f.timecreated as createdat';
         $from = '{files} f
                  JOIN {context} c ON c.id = f.contextid
                  JOIN {course} co ON co.id = c.instanceid';
@@ -84,6 +84,7 @@ class course_table extends \table_sql
             'courseshortname',
             'coursefullname',
             'filename',
+            'filesize',
             'createdat',
             'actions',
         ]);
@@ -93,12 +94,14 @@ class course_table extends \table_sql
             get_string('course_shortname_header', 'tool_lcbackupcoursestep'),
             get_string('course_fullname_header', 'tool_lcbackupcoursestep'),
             get_string('filename_header', 'tool_lcbackupcoursestep'),
+            get_string('filesize_header', 'tool_lcbackupcoursestep'),
             get_string('createdat_header', 'tool_lcbackupcoursestep'),
             get_string('actions_header', 'tool_lcbackupcoursestep'),
         ]);
 
         // Set table attributes.
         $this->sortable(true, 'filename', SORT_DESC);
+        $this->sortable(true, 'filesize', SORT_DESC);
         $this->collapsible(true);
         $this->initialbars(true);
         $this->set_attribute('class', 'admintable generaltable');
@@ -142,5 +145,13 @@ class course_table extends \table_sql
     public function col_createdat($row)
     {
         return userdate($row->createdat);
+    }
+
+    /**
+     * Display size in user friendly format.
+     */
+    public function col_filesize($row)
+    {
+        return display_size($row->filesize);
     }
 }

--- a/lang/en/tool_lcbackupcoursestep.php
+++ b/lang/en/tool_lcbackupcoursestep.php
@@ -21,5 +21,6 @@ $string['course_id_header'] = 'Course ID';
 $string['course_shortname_header'] = 'Course short name';
 $string['course_fullname_header'] = 'Course fullname name';
 $string['filename_header'] = 'File name';
+$string['filesize_header'] = 'File size';
 $string['createdat_header'] = 'Created at';
 $string['actions_header'] = 'Actions';


### PR DESCRIPTION
This adds a filesize column to the courses table. It's useful to know if you're about to download 25 MB or 25 GB.

![image](https://github.com/user-attachments/assets/dcaf1515-e892-4d44-a655-7b8bce904e9b)

**Testing instructions**:
1. Create a test site with a couple courses (use admin/tool/generator/cli/maketestsite.php).
2. Create a category where you can move the courses into, I created a category with name "Backup". 
3. Move a couple courses into the category.
4. Open admin/tool/lifecycle/workflowdrafts.php and click "Create new workflow" button.
5. Give the workflow a new title, I named this "Filesize test" , then click "Save changes".
6. From the "Add new trigger instance" dropdown, select "Categories Trigger"
7. Give the new trigger a name, I gave: this "When course in category" and select the created category in my case "Backup", then click Save changes.
8. From the "Add new step instance" dropdown, select "Backup course step".
9. Give the new step a name, I gave this: "Backup course", then click "Save changes".
10. Open admin/tool/lifecycle/workflowdrafts.php and click the Activate button for the newly created workflow.
11. In a terminal execute the following command: 
```
php admin/cli/scheduled_task.php --execute="\tool_lifecycle\task\lifecycle_task"
```
12. Open admin/tool/lcbackupcoursestep/courses.php and observe the table has "File Size" column, and that the file size column is sortable.