### PR TITLE
Enable backup retrieval after course deletion by storing metadata

### DIFF
--- a/classes/lifecycle/course_table.php
+++ b/classes/lifecycle/course_table.php
@@ -14,6 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
+/**
+ * Table class for handling course backup data.
+ *
+ * @package    tool_lcbackupcoursestep
+ * @copyright  2024 Catalyst
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
 namespace tool_lcbackupcoursestep\lifecycle;
 
 defined('MOODLE_INTERNAL') || die;
@@ -52,11 +60,11 @@ class course_table extends \table_sql {
 
         // Build the SQL.
         $fields = 'f.id as id,
-                   co.id as courseid, co.shortname as courseshortname, co.fullname as coursefullname,
-                   f.filename as filename, f.filesize as filesize, f.timecreated as createdat';
+            md.oldcourseid as courseid, md.shortname as courseshortname, md.fullname as coursefullname,
+            f.filename as filename, f.filesize as filesize, f.timecreated as createdat';
         $from = '{files} f
-                 JOIN {context} c ON c.id = f.contextid
-                 JOIN {course} co ON co.id = c.instanceid';
+              JOIN {context} c ON c.id = f.contextid
+              LEFT JOIN {tool_lcbackupcoursestep_metadata} md ON f.id = md.fileid';
 
         $where = ["f.component = :component AND filename <> '.'"];
         $params = ['component' => 'tool_lcbackupcoursestep'];
@@ -64,17 +72,17 @@ class course_table extends \table_sql {
         // Filtering.
         if ($filterdata) {
             if ($filterdata->shortname) {
-                $where[] = $DB->sql_like('co.shortname', ':shortname', false, false);
+                $where[] = $DB->sql_like('md.shortname', ':shortname', false, false);
                 $params['shortname'] = '%' . $DB->sql_like_escape($filterdata->shortname) . '%';
             }
 
             if ($filterdata->fullname) {
-                $where[] = $DB->sql_like('co.fullname', ':fullname', false, false);
+                $where[] = $DB->sql_like('md.fullname', ':fullname', false, false);
                 $params['fullname'] = '%' . $DB->sql_like_escape($filterdata->fullname) . '%';
             }
 
             if ($filterdata->courseid) {
-                $where[] = 'co.id = :courseid';
+                $where[] = 'md.oldcourseid = :courseid';
                 $params['courseid'] = $filterdata->courseid;
             }
         }

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<XMLDB PATH="admin/tool/lcbackupcoursestep/db" VERSION="2024101000" COMMENT="XMLDB file for Moodle tool/lcbackupcoursestep"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="../../../../lib/xmldb/xmldb.xsd"
+>
+  <TABLES>
+    <TABLE NAME="tool_lcbackupcoursestep_metadata" COMMENT="Metadata for course backups.">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="shortname" TYPE="char" LENGTH="255" NOTNULL="true"/>
+        <FIELD NAME="fullname" TYPE="char" LENGTH="255" NOTNULL="true"/>
+        <FIELD NAME="oldcourseid" TYPE="int" LENGTH="10" NOTNULL="true"/>
+        <FIELD NAME="fileid" TYPE="int" LENGTH="10" NOTNULL="true"/>
+        <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" COMMENT="Timestamp when the backup was created"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="fileid_fk" TYPE="foreign" FIELDS="fileid" REFTABLE="files" REFFIELDS="id"/>
+      </KEYS>
+    </TABLE>
+  </TABLES>
+</XMLDB>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -1,0 +1,102 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Upgrade script for tool_lcbackupcoursestep.
+ *
+ * This script handles any necessary upgrades to the tool_lcbackupcoursestep plugin.
+ *
+ * @package   tool_lcbackupcoursestep
+ * @copyright 2024 Catalyst
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+/**
+ * Performs the upgrade steps for tool_lcbackupcoursestep.
+ *
+ * This function manages all upgrade tasks such as updating database schema,
+ * data migrations, or other necessary steps for upgrading to a new version.
+ *
+ * @param int $oldversion The version of the plugin we are upgrading from.
+ * @return bool True if the upgrade was successful, false otherwise.
+ */
+function xmldb_tool_lcbackupcoursestep_upgrade($oldversion) {
+    global $DB;
+
+    if ($oldversion < 2024101000) {
+
+        $table = new xmldb_table('tool_lcbackupcoursestep_metadata');
+
+        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+        $table->add_field('shortname', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('fullname', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('oldcourseid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('fileid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('timecreated', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+        $table->add_key('fileid_fk', XMLDB_KEY_FOREIGN, ['fileid'], 'files', ['id']);
+
+        if (!$DB->get_manager()->table_exists($table)) {
+            $DB->get_manager()->create_table($table);
+        }
+
+        $sql1 = "
+            INSERT INTO {tool_lcbackupcoursestep_metadata} (shortname, fullname, oldcourseid, fileid, timecreated)
+            SELECT crs.shortname,
+                   crs.fullname,
+                   crs.id AS oldcourseid,
+                   f.id AS fileid,
+                   f.timecreated
+              FROM {files} f
+              JOIN {context} ctx ON ctx.id = f.contextid
+              JOIN {course} crs ON ctx.instanceid = crs.id
+             WHERE ctx.contextlevel = :contextlevel
+               AND f.component = :component
+               AND f.filearea = :filearea
+               AND f.filesize > 0
+        ";
+        $DB->execute($sql1, [
+            'contextlevel' => CONTEXT_COURSE,
+            'component' => 'tool_lcbackupcoursestep',
+            'filearea' => 'course_backup',
+        ]);
+
+        $sql2 = "
+            UPDATE {files}
+               SET contextid = :contextid
+             WHERE id IN (
+                    SELECT f.id
+                      FROM {files} f
+                      JOIN {context} ctx ON ctx.id = f.contextid
+                     WHERE ctx.contextlevel = :contextlevel
+                       AND f.component = :component
+                       AND f.filearea = :filearea
+                   )
+        ";
+        $DB->execute($sql2, [
+            'contextid' => \context_system::instance()->id,
+            'contextlevel' => CONTEXT_COURSE,
+            'component' => 'tool_lcbackupcoursestep',
+            'filearea' => 'course_backup',
+        ]);
+
+        upgrade_plugin_savepoint(true, 2024101000, 'tool', 'lcbackupcoursestep');
+    }
+
+    return true;
+}
+

--- a/tests/step_test.php
+++ b/tests/step_test.php
@@ -139,7 +139,7 @@ class step_test extends \advanced_testcase {
         $processor->process_courses();
 
         // Check that the log file is created.
-        $contextid = \context_course::instance($this->course->id)->id;
+        $contextid = \context_system::instance()->id;
         $sql = "contextid = :contextid
                AND component = :component
                AND filearea = :filearea
@@ -201,5 +201,13 @@ class step_test extends \advanced_testcase {
 
         // There is an assignment in the course.
         $this->assertNotEmpty($DB->get_record('assign', ['course' => $courseid]));
+
+        // Check the metadata table for the file backup entry.
+        $metadata = $DB->get_record('tool_lcbackupcoursestep_metadata', ['fileid' => $file->id]);
+        $this->assertNotEmpty($metadata);
+
+        // Check metadata details.
+        $this->assertEquals($this->course->id, $metadata->oldcourseid);
+        $this->assertEquals($this->course->shortname, $metadata->shortname);
     }
 }

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023100400;
+$plugin->version   = 2024101000;
 $plugin->requires  = 2022041200;
 $plugin->component = 'tool_lcbackupcoursestep';
 


### PR DESCRIPTION
This PR addresses the issue in #5 

**To Test**

Create a test site with a course (use admin/tool/generator/cli/maketestsite.php).

Create a category where you can move the course into.

Move the course into the the newly created category.

Open `admin/tool/lifecycle/workflowdrafts.php` and click "Create new workflow" button.

Give the workflow a new title, then click "Save changes".

From the "Add new trigger instance" dropdown, select "Categories Trigger"

Give the new trigger a name, and Select the Category from the dropdown then click Save changes.

From the "Add new step instance" dropdown, select "Backup course step"

Give the new step a name, then click "Save changes".

Open `admin/tool/lifecycle/workflowdrafts.php` and click the Activate button for the newly created workflow.

![image](https://github.com/user-attachments/assets/2e6154f8-bdb4-421b-9054-b8b6d91024a0)

In a terminal execute the following command

`php admin/cli/scheduled_task.php --execute="\tool_lifecycle\task\lifecycle_task"`

After executing the task, make sure the backup is generated for that course by checking this link:

`admin/tool/lcbackupcoursestep/courses.php`

![image](https://github.com/user-attachments/assets/0788f1c9-9ac4-4d9d-965c-91bb97ec120c)

After this, delete the course by going to `/course/management.php` and deleting the course that you used to create a backup.

Then, open this page: `admin/tool/lcbackupcoursestep/courses.php` 
Confirm you can still see the course backup with the course name and ID (confirm in the database that the course is deleted and that the `mdl_tool_lcbackupcoursestep_metadata` table contains this data).

Click "Restore" (in the action buttons) and complete the restoration.

Confirm the course is restored and working properly.
