### PR TITLE
Fix unit test failing on test_backup_course_step_s3

### DIFF
--- a/tests/step_test.php
+++ b/tests/step_test.php
@@ -249,7 +249,7 @@ class step_test extends \advanced_testcase {
         $processor->process_courses();
 
         // Get the file record.
-        $contextid = \context_course::instance($this->course->id)->id;
+        $contextid = \context_system::instance()->id;
         $sql = "contextid = :contextid
                AND component = :component
                AND filearea = :filearea


### PR DESCRIPTION
Test before: 
```
Failed asserting that a boolean is not empty.
 /var/www/navitas-ncm-uat/admin/tool/lcbackupcoursestep/tests/step_test.php:266
 /var/www/navitas-ncm-uat/lib/phpunit/classes/advanced_testcase.php:80
```
Test result after update : OK (2 tests, 13 assertions)