### PR TITLE
Process courses via adhoc task

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,20 @@ Dependencies
 This plugin depends on the following plugins:
 * Life cycle: https://moodle.org/plugins/view/tool_lifecycle.
 * The following refactoring is accepted https://github.com/learnweb/moodle-tool_lifecycle/pull/189
+
+List of backed up courses
+============
+You can find the list of backed up courses under Life cycle settings.
+
+**List of backed up courses (tool_lcbackupcoursestep)**
+
+URL: https://{your.moodle.site}/admin/category.php?category=lifecycle_category
+
+List of pending adhoc tasks for backups
+============
+You can find the list of pending adhoc tasks for backups under Life cycle settings.
+This page allows users to delete failed tasks.
+
+**Adhoc tasks for course backup (tool_lcbackupcoursestep)**
+
+URL: https://{your.moodle.site}/admin/category.php?category=lifecycle_category

--- a/classes/lifecycle/adhoc_task_table.php
+++ b/classes/lifecycle/adhoc_task_table.php
@@ -1,0 +1,188 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_lcbackupcoursestep\lifecycle;
+
+defined('MOODLE_INTERNAL') || die;
+
+require_once($CFG->libdir . '/tablelib.php');
+
+use html_writer;
+
+/**
+ * Shows the table of adhoc tasks, which show courses that will be backed up.
+ *
+ * @package     tool_lcbackupcoursestep
+ * @copyright   2024 Catalyst IT
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class adhoc_task_table extends \table_sql {
+
+    /**
+     * @var array "cached" lang strings
+     */
+    private $strings;
+
+    /**
+     * Constructor for adhoc_task_table.
+     *
+     * @param array $filterdata Filter data.
+     */
+    public function __construct($filterdata = []) {
+        parent::__construct('tool_lcbackupcoursestep-adhoc-task');
+
+        // Action buttons string.
+        $this->strings = [
+            'delete' => get_string('delete'),
+        ];
+
+        // Build the SQL.
+        $fields = 'ta.id,
+                   ta.customdata,
+                   ta.faildelay,
+                   ta.nextruntime';
+        $from = '{task_adhoc} ta';
+        $where = 'ta.component = :component';
+        $params = [
+            'component' => 'tool_lcbackupcoursestep',
+        ];
+
+        $this->set_sql($fields, $from, $where, $params);
+
+        // Headers.
+        $this->define_headers([
+            get_string('course_id_header', 'tool_lcbackupcoursestep'),
+            get_string('course_fullname_header', 'tool_lcbackupcoursestep'),
+            get_string('workflow_header', 'tool_lcbackupcoursestep'),
+            get_string('next_run_header', 'tool_lcbackupcoursestep'),
+            get_string('faildelay_header', 'tool_lcbackupcoursestep'),
+            get_string('actions'),
+        ]);
+
+        $this->define_columns([
+            'courseid',
+            'coursename',
+            'workflow',
+            'nextruntime',
+            'faildelay',
+            'actions',
+        ]);
+    }
+
+    /**
+     * Course ID table.
+     *
+     * @param object $row The row.
+     * @return string
+     */
+    public function col_courseid($row) {
+        $data = json_decode($row->customdata);
+        return $data->courseid;
+    }
+
+    /**
+     * Course name column.
+     *
+     * @param object $row The row.
+     * @return string
+     */
+    public function col_coursename($row) {
+        global $DB;
+
+        $data = json_decode($row->customdata);
+        // Get the course name.
+        $courseid = $data->courseid;
+        if (!$course = $DB->get_record('course', ['id' => $courseid])) {
+            return get_string('missing_course', 'tool_lcbackupcoursestep');
+        }
+        // Return the course name.
+        return html_writer::link(new \moodle_url('/course/view.php', ['id' => $courseid]), $course->fullname);
+    }
+
+    /**
+     * Workflow information.
+     *
+     * @param object $row The row.
+     * @return string
+     */
+    public function col_workflow($row) {
+        global $DB;
+
+        // Find the workflow.
+        $data = json_decode($row->customdata);
+        $result = $DB->get_record('tool_lifecycle_workflow', ['id' => $data->workflowid]);
+
+        // If no workflow is found, return missing workflow or process message.
+        if (!$result) {
+            return get_string('missing_workflow', 'tool_lcbackupcoursestep');
+        }
+
+        // If workflow is found, return the workflow name and url to the workflow.
+        $url = new \moodle_url('/admin/tool/lifecycle/workflowoverview.php?', ['wf' => $result->id]);
+        return html_writer::link($url, $result->title, ['class' => 'workflow-link']);
+    }
+
+    /**
+     * Next run column.
+     *
+     * @param object $row The row.
+     * @return string
+     */
+    public function col_nextruntime($row) {
+        return userdate($row->nextruntime);
+    }
+
+    /**
+     * Fail delay column.
+     *
+     * @param object $row The row.
+     * @return string
+     */
+    public function col_faildelay($row) {
+        return $row->faildelay;
+    }
+
+    /**
+     * Actions column.
+     *
+     * @param object $row The row.
+     * @return string
+     */
+    public function col_actions($row) {
+        global $OUTPUT;
+
+        // Only show the delete action if the fail delay is greater than 0.
+        if ($row->faildelay > 0) {
+            $data = json_decode($row->customdata);
+            $actionmenu = new \action_menu();
+            $actionmenu->add_primary_action(
+                new \action_menu_link_primary(
+                    new \moodle_url('', [
+                        'action' => 'delete',
+                        'id' => $row->id,
+                        'sesskey' => sesskey(),
+                        'processid' => $data->processid,
+                        'workflowid' => $data->workflowid,
+                    ]),
+                    new \pix_icon('t/delete', $this->strings['delete']),
+                    $this->strings['delete']
+                )
+            );
+            return $OUTPUT->render($actionmenu);
+        }
+        return '';
+    }
+}

--- a/classes/lifecycle/step.php
+++ b/classes/lifecycle/step.php
@@ -74,21 +74,18 @@ class step extends libbase {
         $workflowid = $DB->get_field('tool_lifecycle_process', 'workflowid', ['id' => $processid]);
 
         // Set the custom data.
-        $tashhash = md5($processid . '_' . $instanceid . '_' . $course->id);
+        $taskhash = $this->generate_task_hash($processid, $instanceid, $course);
         $task->set_custom_data((object) [
             'processid' => $processid,
             'stepinstanceid' => $instanceid,
             'courseid' => $course->id,
             'workflowid' => $workflowid,
-            'taskhash' => $tashhash,
+            'taskhash' => $taskhash,
         ]);
 
         // Schedule to run the task after 1 minute.
         $task->set_next_run_time(time() + 60);
         \core\task\manager::queue_adhoc_task($task, true);
-
-        // Log the task creation.
-        mtrace("Adhoc course backup task for the course " . $course->id . " has been created");
 
         // Important, We need to put this to waiting state, so next step has to wait.
         return step_response::waiting();
@@ -105,10 +102,8 @@ class step extends libbase {
     public function process_waiting_course($processid, $instanceid, $course) {
         if ($this->get_adhoc_task($processid, $instanceid, $course)) {
             // Keep waiting for the adhoc task to finish.
-            mtrace("Adhoc course backup task for the course " . $course->id . " is still running, waiting.");
             return step_response::waiting();
         } else {
-            mtrace("Adhoc course backup task for the course " . $course->id . " has finished, proceeding to next step.");
             // Task is finished, proceed to next step.
             return step_response::proceed();
         }
@@ -145,11 +140,11 @@ class step extends libbase {
     private function get_adhoc_task($processid, $instanceid, $course) {
         global $DB;
         // Find adhoc task using hash value.
-        $tashhash = md5($processid . '_' . $instanceid . '_' . $course->id);
+        $taskhash = $this->generate_task_hash($processid, $instanceid, $course);
         $select = $DB->sql_like('customdata', ':taskhash');
         $select  .= ' AND component = :component';
         $params = [
-            'taskhash' => '%' . $tashhash . '%',
+            'taskhash' => '%' . $taskhash . '%',
             'component' => 'tool_lcbackupcoursestep',
         ];
         return $DB->get_record_select('task_adhoc', $select, $params);
@@ -437,5 +432,17 @@ class step extends libbase {
         $ADMIN->add('lifecycle_category', new admin_externalpage('tool_lcbackupcoursestep_tasks',
             get_string('adhoc_tasks', 'tool_lcbackupcoursestep'),
             new moodle_url('/admin/tool/lcbackupcoursestep/tasks.php')));
+    }
+
+    /**
+     * Generate a unique hash for a process, instance, and course.
+     *
+     * @param int $processid
+     * @param int $instanceid
+     * @param object $course
+     * @return string
+     */
+    private function generate_task_hash($processid, $instanceid, $course) {
+        return md5($processid . '_' . $instanceid . '_' . $course->id);
     }
 }

--- a/classes/lifecycle/step.php
+++ b/classes/lifecycle/step.php
@@ -22,13 +22,11 @@ global $CFG;
 require_once($CFG->dirroot . '/admin/tool/lifecycle/step/lib.php');
 
 use admin_externalpage;
-use backup_plan_dbops;
 use core\output\notification;
 use moodle_url;
 use tool_lcbackupcoursestep\s3\helper;
-use tool_lifecycle\local\manager\settings_manager;
+use tool_lcbackupcoursestep\task\course_backup_s3_task;
 use tool_lifecycle\local\response\step_response;
-use tool_lifecycle\settings_type;
 use tool_lifecycle\step\instance_setting;
 use tool_lifecycle\step\libbase;
 
@@ -49,18 +47,17 @@ class step extends libbase {
         return 'tool_lcbackupcoursestep';
     }
 
-
     /**
      * Returns the description.
      *
      * @return string
      */
     public function get_plugin_description() {
-        return "Backup course";
+        return get_string('description', 'tool_lcbackupcoursestep');
     }
 
     /**
-     * Processes the course.
+     * Adhoc task to back up the course.
      *
      * @param int $processid the process id.
      * @param int $instanceid step instance id.
@@ -68,74 +65,94 @@ class step extends libbase {
      * @return step_response
      */
     public function process_course($processid, $instanceid, $course) {
-        $courseid = $course->id;
+        global $DB;
 
-        // Get backup settings.
-        $settings = settings_manager::get_settings($instanceid, settings_type::STEP);
+        // Create and queue adhoc task.
+        $task = new \tool_lcbackupcoursestep\task\course_backup_s3_task();
 
-        // Backup course.
-        $bc = new \backup_controller(\backup::TYPE_1COURSE, $courseid, \backup::FORMAT_MOODLE,
-            \backup::INTERACTIVE_NO, \backup::MODE_GENERAL, get_admin()->id);
+        // Retrieve workflow id to save in custom data.
+        $workflowid = $DB->get_field('tool_lifecycle_process', 'workflowid', ['id' => $processid]);
 
-        // Settings.
-        $backupplan = $bc->get_plan();
-        $keyprefix = "backup_";
-        foreach ($settings as $key => $value) {
-            // The keys are prefixed with backup_, check then remove.
-            if (strpos($key, $keyprefix) !== 0) {
-                continue;
-            }
+        // Set the custom data.
+        $tashhash = md5($processid . '_' . $instanceid . '_' . $course->id);
+        $task->set_custom_data((object) [
+            'processid' => $processid,
+            'stepinstanceid' => $instanceid,
+            'courseid' => $course->id,
+            'workflowid' => $workflowid,
+            'taskhash' => $tashhash,
+        ]);
 
-            $key = substr($key, strlen($keyprefix));
-            $setting = $backupplan->get_setting($key);
+        // Schedule to run the task after 1 minute.
+        $task->set_next_run_time(time() + 60);
+        \core\task\manager::queue_adhoc_task($task, true);
 
-            if ($setting->get_status() === \base_setting::NOT_LOCKED) {
-                $setting->set_value($value);
-            }
+        // Log the task creation.
+        mtrace("Adhoc course backup task for the course " . $course->id . " has been created");
+
+        // Important, We need to put this to waiting state, so next step has to wait.
+        return step_response::waiting();
+    }
+
+    /**
+     * Only proceed if the course backup task has finished.
+     *
+     * @param int $processid
+     * @param int $instanceid
+     * @param mixed $course
+     * @return step_response
+     */
+    public function process_waiting_course($processid, $instanceid, $course) {
+        if ($this->get_adhoc_task($processid, $instanceid, $course)) {
+            // Keep waiting for the adhoc task to finish.
+            mtrace("Adhoc course backup task for the course " . $course->id . " is still running, waiting.");
+            return step_response::waiting();
+        } else {
+            mtrace("Adhoc course backup task for the course " . $course->id . " has finished, proceeding to next step.");
+            // Task is finished, proceed to next step.
+            return step_response::proceed();
         }
+    }
 
-        // Set the default filename.
-        $format = $bc->get_format();
-        $type = $bc->get_type();
-        $id = $bc->get_id();
-        $users = $bc->get_plan()->get_setting('users')->get_value();
-        $anonymised = $bc->get_plan()->get_setting('anonymize')->get_value();
-        $filename = backup_plan_dbops::get_default_backup_filename($format, $type, $id, $users, $anonymised);
-        $backupplan->get_setting('filename')->set_value($filename);
+    /**
+     * Rollback the step.
+     * We only delete the adhoc task if it exists
+     *
+     * @param int $processid of the respective process.
+     * @param int $instanceid of the step instance.
+     * @param mixed $course to be rolled back.
+     */
+    public function rollback_course($processid, $instanceid, $course) {
+        global $DB;
 
-        // Run backup.
-        $bc->execute_plan();
-        $results = $bc->get_results();
-
-        // Copy backup file.
-        $file = $results['backup_destination'];
-        if (!empty($file)) {
-            // Prepare file record.
-            $filerecord = [
-                'contextid' => \context_course::instance($courseid)->id,
-                'component' => 'tool_lcbackupcoursestep',
-                'filearea' => 'course_backup',
-                'itemid' => $instanceid,
-                'filepath' => "/",
-                'filename' => $filename,
-            ];
-
-            // Save file.
-            $fs = get_file_storage();
-            $newfile = $fs->create_file_from_storedfile($filerecord, $file);
-
-            // Upload file to S3.
-            helper::upload_file($processid, $instanceid, $courseid, $newfile);
-
-            // Delete file.
-            $file->delete();
+        // Find the adhoc task.
+        $task = $this->get_adhoc_task($processid, $instanceid, $course);
+        if ($task) {
+            // Delete the adhoc task.
+            $DB->delete_records('task_adhoc', ['id' => $task->id]);
         }
+    }
 
-        // Clean up.
-        $bc->destroy();
-        unset($bc);
-
-        return step_response::proceed();
+    /**
+     * Find adhoc task
+     *
+     * @param int $processid the process id.
+     * @param int $instanceid step instance id.
+     * @param object $course the course object.
+     *
+     * @return \stdClass|false if the task exists.
+     */
+    private function get_adhoc_task($processid, $instanceid, $course) {
+        global $DB;
+        // Find adhoc task using hash value.
+        $tashhash = md5($processid . '_' . $instanceid . '_' . $course->id);
+        $select = $DB->sql_like('customdata', ':taskhash');
+        $select  .= ' AND component = :component';
+        $params = [
+            'taskhash' => '%' . $tashhash . '%',
+            'component' => 'tool_lcbackupcoursestep',
+        ];
+        return $DB->get_record_select('task_adhoc', $select, $params);
     }
 
     /**
@@ -410,9 +427,15 @@ class step extends libbase {
      */
     public function get_plugin_settings() {
         global $ADMIN;
+
         // Page to show the list of backed up courses.
         $ADMIN->add('lifecycle_category', new admin_externalpage('tool_lcbackupcoursestep_courses',
             get_string('backedupcourses', 'tool_lcbackupcoursestep'),
             new moodle_url('/admin/tool/lcbackupcoursestep/courses.php')));
+
+        // Page to show the list of adhoc tasks.
+        $ADMIN->add('lifecycle_category', new admin_externalpage('tool_lcbackupcoursestep_tasks',
+            get_string('adhoc_tasks', 'tool_lcbackupcoursestep'),
+            new moodle_url('/admin/tool/lcbackupcoursestep/tasks.php')));
     }
 }

--- a/classes/s3/helper.php
+++ b/classes/s3/helper.php
@@ -126,7 +126,7 @@ class helper {
         $settings = settings_manager::get_settings($instanceid, settings_type::STEP);
 
         // Do nothing if s3 is not enabled.
-        if (!$settings['uses3']) {
+        if (!isset($settings['uses3'])) {
             return;
         }
 

--- a/classes/s3/helper.php
+++ b/classes/s3/helper.php
@@ -126,7 +126,7 @@ class helper {
         $settings = settings_manager::get_settings($instanceid, settings_type::STEP);
 
         // Do nothing if s3 is not enabled.
-        if (!isset($settings['uses3'])) {
+        if (empty($settings['uses3'])) {
             return;
         }
 

--- a/classes/task/course_backup_s3_task.php
+++ b/classes/task/course_backup_s3_task.php
@@ -1,0 +1,168 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace tool_lcbackupcoursestep\task;
+
+use backup_plan_dbops;
+use tool_lcbackupcoursestep\s3\helper;
+use tool_lifecycle\settings_type;
+use tool_lifecycle\local\manager\settings_manager;
+
+/**
+ * Defines task for course backup.
+ *
+ * @package     tool_lcbackupcoursestep
+ * @copyright   2024 Catalyst IT
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class course_backup_s3_task extends \core\task\adhoc_task {
+    /**
+     * Return the component name.
+     */
+    public function get_component() {
+        return 'tool_lcbackupcoursestep';
+    }
+
+    /**
+     * Run the adhoc task and preform the backup.
+     */
+    public function execute() {
+        global $DB;
+        $customdata = $this->get_custom_data();
+
+        // Workflow id.
+        $workflowid = $customdata->workflowid;
+
+        // Process ID of a lifecycle process.
+        $processid = $customdata->processid;
+
+        // Instance ID of the step.
+        $stepinstanceid = $customdata->stepinstanceid;
+
+        // Course ID to backup.
+        $courseid = $customdata->courseid;
+
+        // Check the IDs.
+        // Check if the course exists.
+        if (!$courseid || !$course = $DB->get_record('course', ['id' => $courseid])) {
+            mtrace('Invalid course id: ' . $courseid . ', task aborted.');
+            return;
+        }
+        // Check if the workflow exists.
+        if (!$workflowid || !$DB->record_exists('tool_lifecycle_workflow', ['id' => $workflowid])) {
+            mtrace('Invalid workflow id: ' . $workflowid . ', task aborted.');
+            return;
+        }
+
+        // Check if the backup task is already running on the same course.
+        $lockfactory = \core\lock\lock_config::get_lock_factory('course_backup_adhoc');
+        if (!$lock = $lockfactory->get_lock('tool_lcbackupcoursestep_adhoc_task_' . $courseid, 10)) {
+            mtrace('Backup adhoc task for: ' . $course->fullname . ' is already running.');
+            return;
+        } else {
+            mtrace('Processing backup for course: ' . $course->fullname);
+        }
+
+        // Process course.
+        try {
+            $this->process_course($processid, $stepinstanceid, $course);
+        } catch (\Exception $e) {
+            mtrace('Error processing course: ' . $course->fullname . ', ' . $e->getMessage());
+        } finally {
+            // Release lock.
+            $lock->release();
+            mtrace('Backup and s3 adhoc task for: ' . $course->fullname . ' completed.');
+        }
+    }
+
+    /**
+     * Processes the course.
+     *
+     * @param int $processid the process id.
+     * @param int $instanceid step instance id.
+     * @param object $course the course object.
+     */
+    private function process_course($processid, $instanceid, $course) {
+        $courseid = $course->id;
+
+        raise_memory_limit(MEMORY_HUGE);
+
+        // Get backup settings.
+        $settings = settings_manager::get_settings($instanceid, settings_type::STEP);
+
+        // Backup course.
+        $bc = new \backup_controller(\backup::TYPE_1COURSE, $courseid, \backup::FORMAT_MOODLE,
+            \backup::INTERACTIVE_NO, \backup::MODE_GENERAL, get_admin()->id);
+
+        // Settings.
+        $backupplan = $bc->get_plan();
+        $keyprefix = "backup_";
+        foreach ($settings as $key => $value) {
+            // The keys are prefixed with backup_, check then remove.
+            if (strpos($key, $keyprefix) !== 0) {
+                continue;
+            }
+
+            $key = substr($key, strlen($keyprefix));
+            $setting = $backupplan->get_setting($key);
+
+            if ($setting->get_status() === \base_setting::NOT_LOCKED) {
+                $setting->set_value($value);
+            }
+        }
+
+        // Set the default filename.
+        $format = $bc->get_format();
+        $type = $bc->get_type();
+        $id = $bc->get_id();
+        $users = $bc->get_plan()->get_setting('users')->get_value();
+        $anonymised = $bc->get_plan()->get_setting('anonymize')->get_value();
+        $filename = backup_plan_dbops::get_default_backup_filename($format, $type, $id, $users, $anonymised);
+        $backupplan->get_setting('filename')->set_value($filename);
+
+        // Run backup.
+        $bc->execute_plan();
+        $results = $bc->get_results();
+
+        // Copy backup file.
+        $file = $results['backup_destination'];
+        if (!empty($file)) {
+            // Prepare file record.
+            $filerecord = [
+                'contextid' => \context_course::instance($courseid)->id,
+                'component' => 'tool_lcbackupcoursestep',
+                'filearea' => 'course_backup',
+                'itemid' => $instanceid,
+                'filepath' => "/",
+                'filename' => $filename,
+            ];
+
+            // Save file.
+            $fs = get_file_storage();
+            $newfile = $fs->create_file_from_storedfile($filerecord, $file);
+
+            // Upload file to S3.
+            helper::upload_file($processid, $instanceid, $courseid, $newfile);
+
+            // Delete file.
+            $file->delete();
+        }
+
+        // Clean up.
+        $bc->destroy();
+        unset($bc);
+    }
+}

--- a/classes/task/course_backup_s3_task.php
+++ b/classes/task/course_backup_s3_task.php
@@ -67,25 +67,14 @@ class course_backup_s3_task extends \core\task\adhoc_task {
             return;
         }
 
-        // Check if the backup task is already running on the same course.
-        $lockfactory = \core\lock\lock_config::get_lock_factory('course_backup_adhoc');
-        if (!$lock = $lockfactory->get_lock('tool_lcbackupcoursestep_adhoc_task_' . $courseid, 10)) {
-            mtrace('Backup adhoc task for: ' . $course->fullname . ' is already running.');
-            return;
-        } else {
-            mtrace('Processing backup for course: ' . $course->fullname);
-        }
-
         // Process course.
         try {
+            mtrace('Processing backup for course: ' . $course->fullname);
             $this->process_course($processid, $stepinstanceid, $course);
         } catch (\Exception $e) {
             mtrace('Error processing course: ' . $course->fullname . ', ' . $e->getMessage());
-        } finally {
-            // Release lock.
-            $lock->release();
-            mtrace('Backup and s3 adhoc task for: ' . $course->fullname . ' completed.');
         }
+        mtrace('Backup and s3 adhoc task for: ' . $course->fullname . ' completed.');
     }
 
     /**

--- a/courses.php
+++ b/courses.php
@@ -21,7 +21,6 @@
  * @copyright   2024 Catalyst IT
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-
 use tool_lcbackupcoursestep\lifecycle\course_table;
 
 require_once(__DIR__ . '/../../../config.php');
@@ -99,7 +98,7 @@ if ($mform->is_cancelled()) {
 echo $OUTPUT->header();
 $mform->display();
 
-// Show log table.
+// Show backed up courses.
 $table = new course_table($data);
 $table->define_baseurl($PAGE->url);
 $table->out(100, false);

--- a/lang/en/tool_lcbackupcoursestep.php
+++ b/lang/en/tool_lcbackupcoursestep.php
@@ -22,17 +22,25 @@
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-$string['pluginname'] = 'Backup course step';
+$string['pluginname'] = 'Adhoc course backup step';
 $string['privacy:metadata'] = 'The plugin does not store any personal data.';
-$string['backedupcourses'] = 'Backed up courses';
+$string['adhoc_tasks'] = 'Adhoc tasks for course backup (tool_lcbackupcoursestep)';
+$string['adhocbackupstasks'] = 'Pending adhoc tasks for course backup';
+$string['adhocbackupstasksdescription'] = 'This page show a list of adhoc tasks that are waiting to be processed. You can also delete any failed task if required.';
+$string['backedupcourses'] = 'List of backed up courses (tool_lcbackupcoursestep)';
 $string['backupsettings'] = 'Backup settings';
 $string['course_id_header'] = 'Course ID';
 $string['course_shortname_header'] = 'Course short name';
-$string['course_fullname_header'] = 'Course fullname name';
+$string['course_fullname_header'] = 'Course full name';
+$string['description'] = 'Backup courses using adhoc tasks.';
 $string['filename_header'] = 'File name';
 $string['filesize_header'] = 'File size';
 $string['createdat_header'] = 'Created at';
+$string['faildelay_header'] = 'Fail delay';
 $string['actions_header'] = 'Actions';
+$string['missing_course'] = 'Missing course';
+$string['missing_workflow'] = 'Missing workflow';
+$string['next_run_header'] = 'Next run time';
 $string['s3_bucket'] = 'Bucket';
 $string['s3_connection_error'] = 'Connection error: {$a}';
 $string['s3_connection_success'] = 'Connection successful';
@@ -43,5 +51,6 @@ $string['s3_unmet_dependency'] = 'This Amazon S3 feature is optional and require
 $string['s3_useproxy'] = 'Use proxy';
 $string['s3_usesdkcreds'] = 'Use the default credential provider chain to find AWS credentials';
 $string['s3settings'] = 'Amazon S3 settings';
+$string['taskfailed'] = 'Adhoc task failed';
 $string['uses3'] = 'Push backups to Amazon S3 bucket';
-
+$string['workflow_header'] = 'Workflow';

--- a/lang/en/tool_lcbackupcoursestep.php
+++ b/lang/en/tool_lcbackupcoursestep.php
@@ -29,6 +29,7 @@ $string['adhocbackupstasks'] = 'Pending adhoc tasks for course backup';
 $string['adhocbackupstasksdescription'] = 'This page show a list of adhoc tasks that are waiting to be processed. You can also delete any failed task if required.';
 $string['backedupcourses'] = 'List of backed up courses (tool_lcbackupcoursestep)';
 $string['backupsettings'] = 'Backup settings';
+$string['confirmdeletetask'] = 'Are you sure you want to delete this task?';
 $string['course_id_header'] = 'Course ID';
 $string['course_shortname_header'] = 'Course short name';
 $string['course_fullname_header'] = 'Course full name';

--- a/tasks.php
+++ b/tasks.php
@@ -1,0 +1,79 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+
+/**
+ * Displays adhoc tasks for course backup.
+ *
+ * @package     tool_lcbackupcoursestep
+ * @copyright   2024 Catalyst IT
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+require_once(__DIR__ . '/../../../config.php');
+require_once($CFG->libdir . '/adminlib.php');
+
+use \tool_lcbackupcoursestep\lifecycle\adhoc_task_table;
+use \tool_lifecycle\local\manager\delayed_courses_manager;
+use \tool_lifecycle\local\manager\process_manager;
+
+require_login();
+require_capability('moodle/site:config', context_system::instance());
+admin_externalpage_setup('tool_lcbackupcoursestep_tasks');
+
+$PAGE->set_context(context_system::instance());
+$PAGE->set_url(new \moodle_url('/admin/tool/lcbackupcoursestep/tasks.php'));
+$PAGE->set_title(get_string('adhocbackupstasks', 'tool_lcbackupcoursestep'));
+$PAGE->set_heading(get_string('adhocbackupstasks', 'tool_lcbackupcoursestep'));
+
+echo $OUTPUT->header();
+
+// Description of the page in an info box.
+echo $OUTPUT->box_start('generalbox boxaligncenter', 'description');
+echo $OUTPUT->box(get_string('adhocbackupstasksdescription', 'tool_lcbackupcoursestep'), 'description');
+echo $OUTPUT->box_end();
+
+$action = optional_param('action', '', PARAM_ALPHA);
+if (!empty($action)) {
+    global $DB;
+    require_sesskey();
+
+    // Params.
+    $id = required_param('id', PARAM_INT);
+    $processid = required_param('processid', PARAM_INT);
+    $workflowid = required_param('workflowid', PARAM_INT);
+
+    $returnurl = new \moodle_url('/admin/tool/lcbackupcoursestep/tasks.php');
+
+    if ($action === 'delete') {
+        // Check if the process still exists.
+        $process = process_manager::get_process_by_id($processid);
+        if ($process) {
+            process_manager::rollback_process($process);
+            delayed_courses_manager::set_course_delayed_for_workflow($process->courseid, true, $workflowid);
+        } else {
+            $DB->delete_records('task_adhoc', ['id' => $id]);
+        }
+    }
+    redirect($returnurl);
+}
+
+// Show adhoc task table.
+$tasktable = new adhoc_task_table();
+$tasktable->define_baseurl($PAGE->url);
+$tasktable->out(100, false);
+
+echo $OUTPUT->footer();

--- a/tasks.php
+++ b/tasks.php
@@ -39,13 +39,6 @@ $PAGE->set_url(new \moodle_url('/admin/tool/lcbackupcoursestep/tasks.php'));
 $PAGE->set_title(get_string('adhocbackupstasks', 'tool_lcbackupcoursestep'));
 $PAGE->set_heading(get_string('adhocbackupstasks', 'tool_lcbackupcoursestep'));
 
-echo $OUTPUT->header();
-
-// Description of the page in an info box.
-echo $OUTPUT->box_start('generalbox boxaligncenter', 'description');
-echo $OUTPUT->box(get_string('adhocbackupstasksdescription', 'tool_lcbackupcoursestep'), 'description');
-echo $OUTPUT->box_end();
-
 $action = optional_param('action', '', PARAM_ALPHA);
 if (!empty($action)) {
     global $DB;
@@ -59,6 +52,24 @@ if (!empty($action)) {
     $returnurl = new \moodle_url('/admin/tool/lcbackupcoursestep/tasks.php');
 
     if ($action === 'delete') {
+        $confirm = optional_param('confirm', 0, PARAM_INT);
+
+        if (!$confirm) {
+            $message = get_string('confirmdeletetask', 'tool_lcbackupcoursestep');
+            $yesurl = new \moodle_url($PAGE->url, [
+                'action' => 'delete',
+                'id' => $id,
+                'processid' => $processid,
+                'workflowid' => $workflowid,
+                'sesskey' => sesskey(),
+                'confirm' => 1,
+            ]);
+            echo $OUTPUT->header();
+            echo $OUTPUT->confirm($message, $yesurl, $returnurl);
+            echo $OUTPUT->footer();
+            exit();
+        }
+
         // Check if the process still exists.
         $process = process_manager::get_process_by_id($processid);
         if ($process) {
@@ -70,6 +81,13 @@ if (!empty($action)) {
     }
     redirect($returnurl);
 }
+
+echo $OUTPUT->header();
+
+// Description of the page in an info box.
+echo $OUTPUT->box_start('generalbox boxaligncenter', 'description');
+echo $OUTPUT->box(get_string('adhocbackupstasksdescription', 'tool_lcbackupcoursestep'), 'description');
+echo $OUTPUT->box_end();
 
 // Show adhoc task table.
 $tasktable = new adhoc_task_table();

--- a/tests/step_test.php
+++ b/tests/step_test.php
@@ -138,9 +138,34 @@ class step_test extends \advanced_testcase {
         // Run trigger.
         process_manager::manually_trigger_process($this->course->id, $this->trigger->id);
 
+        $this->expectOutputString(
+            // First process_courses.
+            "Adhoc course backup task for the course " . $this->course->id . " has been created\n" .
+            // Second process_courses.
+            "Adhoc course backup task for the course " . $this->course->id . " is still running, waiting.\n" .
+            // Adhoc task output.
+            "Processing backup for course: Test course 1\n" .
+            "Backup and s3 adhoc task for: Test course 1 completed.\n" .
+            // Final output.
+            "Adhoc course backup task for the course " . $this->course->id . " has finished, proceeding to next step.\n"
+        );
+
         // Run processor.
         $processor = new processor();
         $processor->process_courses();
+
+        // Run processor again to process the course. This should keep the process in waiting state.
+        $processor->process_courses();
+        $process = $DB->get_record('tool_lifecycle_process', ['courseid' => $this->course->id, 'waiting' => 1]);
+        $this->assertNotEmpty($process);
+
+        // Run adhoc tasks.
+        $this->runAdhocTasks('\tool_lcbackupcoursestep\task\course_backup_s3_task');
+
+        // There should be no process.
+        $processor->process_courses();
+        $process = $DB->get_record('tool_lifecycle_process', ['courseid' => $this->course->id]);
+        $this->assertEmpty($process, 'There should be no process for the course.');
 
         // Check that the log file is created.
         $contextid = \context_course::instance($this->course->id)->id;
@@ -239,6 +264,18 @@ class step_test extends \advanced_testcase {
         // Run processor.
         $processor = new processor();
         $processor->process_courses();
+
+        // Makre sure the processor still exists and in waiting state.
+        $process = $DB->get_record('tool_lifecycle_process', ['courseid' => $this->course->id, 'waiting' => 1]);
+        $this->assertNotEmpty($process);
+
+        // Run adhoc tasks.
+        $this->expectOutputString(
+            "Adhoc course backup task for the course " . $this->course->id . " has been created\n" .
+            "Processing backup for course: Test course 1\n" .
+            "Backup and s3 adhoc task for: Test course 1 completed.\n"
+        );
+        $this->runAdhocTasks('\tool_lcbackupcoursestep\task\course_backup_s3_task');
 
         // Get the file record.
         $contextid = \context_course::instance($this->course->id)->id;

--- a/tests/step_test.php
+++ b/tests/step_test.php
@@ -139,15 +139,9 @@ class step_test extends \advanced_testcase {
         process_manager::manually_trigger_process($this->course->id, $this->trigger->id);
 
         $this->expectOutputString(
-            // First process_courses.
-            "Adhoc course backup task for the course " . $this->course->id . " has been created\n" .
-            // Second process_courses.
-            "Adhoc course backup task for the course " . $this->course->id . " is still running, waiting.\n" .
             // Adhoc task output.
             "Processing backup for course: Test course 1\n" .
-            "Backup and s3 adhoc task for: Test course 1 completed.\n" .
-            // Final output.
-            "Adhoc course backup task for the course " . $this->course->id . " has finished, proceeding to next step.\n"
+            "Backup and s3 adhoc task for: Test course 1 completed.\n"
         );
 
         // Run processor.
@@ -271,7 +265,7 @@ class step_test extends \advanced_testcase {
 
         // Run adhoc tasks.
         $this->expectOutputString(
-            "Adhoc course backup task for the course " . $this->course->id . " has been created\n" .
+        // Adhoc task output.
             "Processing backup for course: Test course 1\n" .
             "Backup and s3 adhoc task for: Test course 1 completed.\n"
         );

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023100402;
+$plugin->version   = 2023100404;
 $plugin->requires  = 2020061500;
 $plugin->component = 'tool_lcbackupcoursestep';
 


### PR DESCRIPTION
Testing instruction:

1. Create 2 course in a category
2. Create A Life cycle workflow with a category trigger and a  tool_lcbackupcoursestep step
3. Set category trigger to work on the category in step 1
4. Turn off cron tab on server (if it is set up), so that we can run it manually for testing purposes
5. Activate the workflow
6. Run cron job
7. Go to **Adhoc tasks for course backup (tool_lcbackupcoursestep)**  https://{your.moodle.site}/admin/tool/lcbackupcoursestep/tasks.php
8. This page should display 2 adhoc tasks
9. Login to database server, and set 'fail relay' of 60 for one of the tasks
10. Go back to the page in step 7
11. We can now delete the task with "fail delay"
12. Run cron job again
13. Go to **List of backed up courses (tool_lcbackupcoursestep)** https://{your.moodle.site}/admin/tool/lcbackupcoursestep/courses.php
14. There should be one backed up course
