### PR TITLE
Add missing required file

### DIFF
--- a/classes/task/course_backup_s3_task.php
+++ b/classes/task/course_backup_s3_task.php
@@ -16,6 +16,9 @@
 
 namespace tool_lcbackupcoursestep\task;
 
+defined('MOODLE_INTERNAL') || die();
+require_once($CFG->dirroot . '/backup/util/includes/backup_includes.php');
+
 use backup_controller;
 use backup_plan_dbops;
 use tool_lcbackupcoursestep\s3\helper;


### PR DESCRIPTION
We still got the error.

Adhoc task failed: tool_lcbackupcoursestep\task\course_backup_s3_task,Class 'backup_controller' not found

However I cannot replicate on my local dev